### PR TITLE
fix pipe-all button not working with projects that have repeating events but no repeating forms

### DIFF
--- a/CrossprojectpipingExternalModule.php
+++ b/CrossprojectpipingExternalModule.php
@@ -1020,10 +1020,18 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 							if ($repeatable === false) {
 								$data_to_save[$dst_rid][$dst_event_id][$dst_name] = $field_value;
 							} else {
+								// create an instance of destination project
+								$destProj = new \Project($this->projects['destination']['projectId']);
+								// check to see if destination project has repeating forms
+								$hasRepeatingForms = $destProj->hasRepeatingForms();
 								foreach($instances as $instance) {
 									$json_data = '{"record_id":"' . $dst_rid .
-										'","redcap_event_name":"'. $this->projects['destination']['event_details'][$dst_event_id]['unique_name'] .
-										'","redcap_repeat_instrument":"'. $form_name .
+										'","redcap_event_name":"'. $this->projects['destination']['event_details'][$dst_event_id]['unique_name'];
+									// if destination project has repeating form(s), add `redcap_repeat_instrument` field to json data
+									if ($hasRepeatingForms === true) {
+										$json_data = $json_data . '","redcap_repeat_instrument":"'. $form_name;
+									}
+									$json_data = $json_data .
 										'","redcap_repeat_instance":'. $instance .
 										',"' . $dst_name . '":"' . $field_value . '"}';
 									array_push($data_repeatable_to_save, json_decode($json_data));


### PR DESCRIPTION
Currently the pipe-all button works with:
- Normal projects
- Projects with repeatable instruments and one event
- Projects with repeatable instruments and multiple events - but with repeatable forms

Pipe-all button is not working with projects that have repeatable instruments and multiple events but with no repeatable forms.

For a simple illustration, this is related to these options within `Repeatable instruments and events` settings:

<img width="431" alt="Screen Shot 2022-11-26 at 02 06 57" src="https://user-images.githubusercontent.com/15029492/204043324-69c9f666-55fd-4ec5-8ac2-d85a0e6d03db.png">

Whereas:
- Repeat entire event => has no repeatable forms
- Repeat instruments => has repeatable forms

This fix ensures pipe-all works with both cases.
