### PR TITLE
Escaped error output

### DIFF
--- a/php/pipe_all_data_ajax.php
+++ b/php/pipe_all_data_ajax.php
@@ -49,7 +49,7 @@ $changed_records = $pipe_attempts - $no_change_records;
 if (empty($errors)) {
 	$response['success'] = true;
 } else {
-	$response['error'] = implode('. ', $errors);
+	$response['error'] = implode('. ', $module->escape($errors));
 }
 
 echo json_encode($response);


### PR DESCRIPTION
@moorejr5, the `$returnarray['data-list'][$dst_rid]` line technically introduces a potential injection vulnerability (found via the scan script).   This PE should address it, and should be a safe change assuming the error output is simply displayed.  Does this change look good to do you?