### PR TITLE
Add config and code to get latest record ID if multiple

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,6 +67,13 @@
 					"repeatable": false
 				},
 				{
+					"key": "use-latest-record-id",
+					"name": "If multiple Records for Unique Match Field, use the newest Record Id? (only works if Record Names are auto-incrementing integers)",
+					"required": false,
+					"type": "checkbox",
+					"repeatable": false
+				},
+				{
 					"key": "project-fields",
 					"name": "Pipe Field",
 					"required": false,

--- a/getValue.php
+++ b/getValue.php
@@ -50,13 +50,21 @@
 	} else {
 		$matchSource = (empty($matchSource)) ? $thismatch : $matchSource ;
 		$filterData = \REDCap::getData($_POST['otherpid'], 'array', null, null, null, null, false, false, false, "([$matchSource] = '$matchRecord')");
-		if(count($filterData) != 1){
-			// Either there were no matches or multiple matches.  Either way, we want to return without echo-ing any values.
-			return;
-		}
 
-		reset($filterData);
-		$recordId = key($filterData);
+		if (count($filterData) != 1) {
+			$useLatestRecordIdSetting = $module->getProjectSetting('use-latest-record-id');
+			if (!is_null($useLatestRecordIdSetting) && isset($useLatestRecordIdSetting[0]) && $useLatestRecordIdSetting[0] === true) {
+				// get the largest record ID
+				ksort($filterData);
+				$recordId = array_key_last($filterData);
+			} else {
+				// Either there were no matches or multiple matches.  Either way, we want to return without echo-ing any values.
+				return;
+			}
+		} else {
+			reset($filterData);
+			$recordId = key($filterData);
+		}
 	}
 
 	$data = \Records::getData($_POST['otherpid'], 'array', array($recordId));


### PR DESCRIPTION
I am working with the PMI team on a solution that uses this plugin where the source project has an ID column called "snapshot_id".  Because of a data integrity issue, there can be multiple records with the same snapshot_id, and the client always needs the most recent one.  I could fork this EM and make my change for their needs, but I thought I would first consider making it an option on the existing plug-in.  

This PR creates a new project-level config option called ``'use-latest-record-id'` that will use the latest record-id if multiple records exist for the Unique Match Field.  The code logic is doing a simple `ksort`, so this only works for auto incr int IDs, but that is the default behavior so I think it is useful. 

What do you think?