### PR TITLE
Feature extension/pipe on save

### DIFF
--- a/CrossprojectpipingExternalModule.php
+++ b/CrossprojectpipingExternalModule.php
@@ -66,14 +66,7 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 		self::$isPipingInProgress = true;
 		try {
 			$this->projects = $this->getProjects();
-
-			// processDataTransfer() reads 'projectId' (camelCase) but getProjects() sets
-			// 'project_id' (snake_case). Alias here so we don't rely on \Project(null)
-			// falling back to the PROJECT_ID constant.
 			$this->projects['destination']['projectId'] = $this->projects['destination']['project_id'];
-
-			$this->getSourceProjectsData();
-			$this->getDestinationProjectData();
 
 			$this->active_forms = $this->getProjectSetting('active-forms');
 			if (count($this->active_forms) == 1 && empty($this->active_forms[0])) {
@@ -81,7 +74,28 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 			}
 			$this->pipe_on_status = $this->getProjectSetting('pipe-on-status');
 
-			// Guarded piping — uses direct SQL guards instead of array-based formStatuses
+			// 1. Fetch destination record's match field values (scoped to single record)
+			$this->getDestinationProjectDataForRecord($record);
+
+			// 2. Derive dest_match_info from the populated records_match_fields
+			$dest_match_info = $this->projects['destination']['records_match_fields'][$record] ?? [];
+
+			// 3. Early return if all match field values are empty — nothing to match against
+			$has_match_value = false;
+			foreach ($dest_match_info as $field => $value) {
+				if ($value !== '' && $value !== null) {
+					$has_match_value = true;
+					break;
+				}
+			}
+			if (!$has_match_value) {
+				return;
+			}
+
+			// 4. Fetch source project data scoped to records matching dest_match_info
+			$this->getSourceProjectsDataForRecord($dest_match_info);
+
+			// 5. Guarded piping (unchanged from Commit 2)
 			$this->pipeToRecordSaveHook($record);
 		} finally {
 			self::$isPipingInProgress = false;
@@ -1010,8 +1024,14 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 	}
 
 	/**
-	 * Checks whether a form/instance is locked.
-	 * Extracted from inline SQL in processRecord() (lines 382-386).
+	 * Checks whether a specific form/instance is locked in the redcap_locking_data table.
+	 *
+	 * Extracted from the inline SQL guard in processRecord(), which performs
+	 * the same check for the form-load path. This standalone version is parameterized for
+	 * reuse across server-side paths (save-hook, batch).
+	 *
+	 * In a future refactor, this method could replace the inline SQL in processRecord(),
+	 * providing a single source of truth for locking checks across all piping paths.
 	 */
 	function isFormLocked($project_id, $record, $event_id, $form_name, $instance) {
 		$project_id = intval($project_id);
@@ -1038,8 +1058,15 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 	}
 
 	/**
-	 * Checks whether a form's status exceeds the pipe-on-status threshold.
-	 * Extracted from inline SQL in processRecord() (lines 390-401).
+	 * Checks whether a form's completion status exceeds the configured pipe-on-status threshold.
+	 *
+	 * Extracted from the inline SQL guard in processRecord(), which performs
+	 * the same check for the form-load path. Also parallels the array-based check in
+	 * processDataTransfer(), which uses pre-fetched formStatuses data.
+	 *
+	 * In a future refactor, this method could replace both the inline SQL in processRecord()
+	 * and the array-based check in processDataTransfer(), providing a single source of truth
+	 * for pipe-on-status enforcement across all piping paths.
 	 */
 	function isFormAbovePipeStatus($project_id, $record, $event_id, $form_name, $instance, $pipe_on_status) {
 		if ($pipe_on_status === null || $pipe_on_status === '') return false;
@@ -1071,7 +1098,13 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 
 	/**
 	 * Checks whether a form is on the configured active-forms list.
-	 * Extracted from inline check in processRecord() (lines 374-378).
+	 *
+	 * Extracted from the inline check in processRecord(), which performs
+	 * the same filtering for the form-load path. Also parallels the check in
+	 * processDataTransfer().
+	 *
+	 * In a future refactor, this method could replace both inline checks, providing a
+	 * single source of truth for active-form filtering across all piping paths.
 	 */
 	function isFormOnActiveList($form_name, $active_forms) {
 		// Empty list or framework [null] quirk means all forms are active
@@ -1082,8 +1115,16 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 
 	/**
 	 * Batch-fetches all locking data for a project in a single SQL query.
-	 * Returns [$record][$event_id][$form_name][$instance] = true for O(1) lookups.
-	 * Currently unused — intended for future batch path optimization.
+	 *
+	 * Returns a nested lookup array for O(1) lock checks per form/instance.
+	 * Currently unused — isFormLocked() performs per-form queries which is
+	 * appropriate for the single-record save-hook path. This method is intended
+	 * for future use in the batch ("Pipe All Records") path where per-form queries
+	 * would be prohibitively expensive (N records × M forms = N×M queries).
+	 *
+	 * In a future refactor, the batch endpoint (pipe_all_data_ajax.php) could call
+	 * prefetchLockingData() once, then check the returned array instead of calling
+	 * isFormLocked() per form, closing the batch path's locking gap efficiently.
 	 */
 	function prefetchLockingData($project_id) {
 		$project_id = intval($project_id);
@@ -1100,8 +1141,13 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 	}
 
 	/**
-	 * Returns a cached \Project instance, avoiding repeated instantiation.
-	 * processDataTransfer() creates new \Project() on every call.
+	 * Returns a cached \Project instance, avoiding repeated instantiation in loops.
+	 *
+	 * processDataTransfer() creates a new \Project() on every call.
+	 * In the save-hook path this is called once; in the batch path it's called
+	 * once per source record per destination record. This method provides the
+	 * caching layer for pipeToRecordSaveHook() and could replace the inline
+	 * instantiation in processDataTransfer() in a future refactor.
 	 */
 	function getCachedProject($pid) {
 		$pid = intval($pid);
@@ -1136,7 +1182,54 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 			$this->projects['source'][$project_index]['source_data'] = \REDCap::getData($params);
 		}
 	}
-	
+
+	/**
+	 * Save-hook variant of getSourceProjectsData(). Fetches source data scoped to records
+	 * matching a specific destination match value, instead of all non-empty records.
+	 *
+	 * For each source project, uses filterLogic with an exact-match expression
+	 * ([$match_field] = 'value') instead of the broad non-empty filter ([$match_field] <> '').
+	 * If the destination has no value for a source project's match field, that source project's
+	 * source_data is set to an empty array (no fetch at all).
+	 *
+	 * @param array $dest_match_info Destination record's match field values,
+	 *        keyed by field name (from records_match_fields[$record]).
+	 */
+	function getSourceProjectsDataForRecord($dest_match_info) {
+		foreach ($this->projects['source'] as $project_index => $project) {
+			$project_id = $project['project_id'];
+			$match_field = $project['source_match_field'];
+			$dest_match_field = $project['dest_match_field'];
+
+			// Look up the destination record's value for this source project's match field
+			$match_value = $dest_match_info[$dest_match_field] ?? '';
+
+			// If the destination has no match value, there's nothing to match against —
+			// skip the fetch entirely
+			if ($match_value === '' || $match_value === null) {
+				$this->projects['source'][$project_index]['source_data'] = [];
+				continue;
+			}
+
+			$fields = $project['source_fields'];
+			if (!in_array($match_field, $fields)) {
+				$fields[] = $match_field;
+			}
+
+			// Escape single quotes in the match value for filterLogic
+			$escaped_value = str_replace("'", "\\'", $match_value);
+
+			$params = [
+				'project_id' => $project_id,
+				'return_format' => 'array',
+				'fields' => $fields,
+				'filterLogic' => "[$match_field] = '$escaped_value'"
+			];
+
+			$this->projects['source'][$project_index]['source_data'] = \REDCap::getData($params);
+		}
+	}
+
 	function getDestinationProjectData() {
 		if (gettype($this->projects) == 'Array') {
 			throw new \Exception("The Cross Project Piping module expected \$module->projects to be an array before calling pipeToRecord()");
@@ -1169,7 +1262,46 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 		
 		$this->projects['destination']['records_match_fields'] = $data;
 	}
-	
+
+	/**
+	 * Save-hook variant of getDestinationProjectData(). Fetches match field values
+	 * for a single destination record instead of all records.
+	 *
+	 * Uses 'records' => [$record_id] in REDCap::getData() params to scope the fetch.
+	 * Populates the same records_match_fields data structure as getDestinationProjectData().
+	 *
+	 * @param string $record_id The destination record to fetch match field values for.
+	 */
+	function getDestinationProjectDataForRecord($record_id) {
+		// get all destination match field names
+		$match_field_names = [];
+		foreach ($this->projects['source'] as $project_index => $project) {
+			$match_field_names[] = $project['dest_match_field'];
+		}
+		$match_field_names = array_unique($match_field_names);
+
+		$params = [
+			'project_id' => $this->projects['destination']['project_id'],
+			'return_format' => 'array',
+			'fields' => $match_field_names,
+			'records' => [$record_id]
+		];
+		$data = \REDCap::getData($params);
+
+		// extract match field info from event arrays (same as getDestinationProjectData)
+		foreach($data as $rid => $events) {
+			$match_info = [];
+			foreach ($events as $eid => $recdata) {
+				foreach($recdata as $field => $value) {
+					$match_info["$field"] = $value;
+				}
+			}
+			$data[$rid] = $match_info;
+		}
+
+		$this->projects['destination']['records_match_fields'] = $data;
+	}
+
 	function pipeToRecord($dst_rid) {
 		if (gettype($this->projects) == 'Array') {
 			throw new \Exception("The Cross Project Piping module expected \$module->projects to be an array before calling pipeToRecord()");
@@ -1231,10 +1363,33 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 	}
 
 	/**
-	 * Save-hook piping wrapper with full guard enforcement.
-	 * Duplicates pipeToRecord() + processDataTransfer() iteration with three guards
-	 * (locking, active-forms, pipe-on-status) checked before any write per field.
-	 * Delegates data assembly to updateDestinationData() (unchanged).
+	 * Save-hook-specific piping method that replaces pipeToRecord() in the save-hook path.
+	 *
+	 * This method duplicates the core logic of pipeToRecord() and
+	 * processDataTransfer() with three key differences:
+	 *
+	 * 1. Uses getCachedProject() instead of inline new \Project() instantiation.
+	 * 2. Enforces a complete guard decision block before any write for each
+	 *    form/instance — all three guards are checked at the same point:
+	 *    - isFormLocked(): skip if form/instance is locked
+	 *    - isFormOnActiveList(): skip if form is not on the active-forms list
+	 *    - isFormAbovePipeStatus(): skip if form status exceeds threshold
+	 * 3. Still uses broad-fetched data from $this->projects (same as Commit 1).
+	 *    Commit 3 replaces broad fetches with scoped single-record fetches.
+	 *
+	 * The duplication boundary is the iteration and guard logic only. This method
+	 * delegates actual data structure assembly to the existing updateDestinationData(),
+	 * which is called as-is without modification.
+	 *
+	 * This duplication exists because the original pipeToRecord() and processDataTransfer()
+	 * cannot be modified under project constraints. The originals remain the code path for
+	 * the batch endpoint (pipe_all_data_ajax.php) and are untouched.
+	 *
+	 * In a future refactor, this guarded logic could be merged back into
+	 * processDataTransfer() (adding the locking check alongside the existing active-form
+	 * and status checks), and pipeToRecord() could be updated to use scoped fetches when
+	 * operating on a single record. This would collapse the duplication and give all paths
+	 * (form-load, save-hook, batch) consistent guard enforcement.
 	 */
 	function pipeToRecordSaveHook($dst_rid) {
 		$record_match_info = $this->projects['destination']['records_match_fields'][$dst_rid];

--- a/CrossprojectpipingExternalModule.php
+++ b/CrossprojectpipingExternalModule.php
@@ -13,6 +13,8 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 	public $modSettings;
 	public $hideButton = false;
 
+	private static $isPipingInProgress = false;
+
 	function redcap_every_page_before_render($project_id) {
 		$user_is_at_record_status_dashboard = $_SERVER['SCRIPT_NAME'] == APP_PATH_WEBROOT . "DataEntry/record_status_dashboard.php";
 		$pipe_all_records_button_configured = $this->getProjectSetting('piping-all-records-button');
@@ -44,6 +46,42 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 		 * and be made aware of concerns & past discussion.
 		 * For details, see https://redcap.vanderbilt.edu/community/post.php?id=99013
 		 */
+	}
+
+	/**
+	 * Pipe-on-save: server-side piping on record save (data entry only, not surveys).
+	 * Reuses the same pipeline as pipe_all_data_ajax.php. Gated by 'pipe-on-save' config.
+	 * $isPipingInProgress prevents recursion from pipeToRecord() -> saveData() -> this hook.
+	 */
+	function redcap_save_record($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id, $repeat_instance) {
+		if (empty($record)) return;                          // no ID yet (new record)
+		if (self::$isPipingInProgress) return;                // recursion guard
+		if (!empty($survey_hash)) return;                     // surveys excluded
+		if (!$this->getProjectSetting('pipe-on-save')) return; // feature not enabled
+
+		self::$isPipingInProgress = true;
+		try {
+			$this->projects = $this->getProjects();
+
+			// processDataTransfer() reads 'projectId' (camelCase) but getProjects() sets
+			// 'project_id' (snake_case). Alias here so we don't rely on \Project(null)
+			// falling back to the PROJECT_ID constant.
+			$this->projects['destination']['projectId'] = $this->projects['destination']['project_id'];
+
+			$this->getSourceProjectsData();
+			$this->getDestinationProjectData();
+
+			$this->active_forms = $this->getProjectSetting('active-forms');
+			if (count($this->active_forms) == 1 && empty($this->active_forms[0])) {
+				$this->active_forms = [];  // framework quirk: [[0] => null]
+			}
+			$this->pipe_on_status = $this->getProjectSetting('pipe-on-status');
+			$this->formStatuses = $this->getFormStatusAllRecords($this->active_forms);
+
+			$this->pipeToRecord($record);
+		} finally {
+			self::$isPipingInProgress = false;
+		}
 	}
 
 	function redcap_module_save_configuration($project_id) {

--- a/CrossprojectpipingExternalModule.php
+++ b/CrossprojectpipingExternalModule.php
@@ -15,6 +15,10 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 
 	private static $isPipingInProgress = false;
 
+	/** Batch locking cache populated by prefetchLockingData(). Reserved for future batch optimization. */
+	private $lockingCache = null;
+	private $projectCache = [];
+
 	function redcap_every_page_before_render($project_id) {
 		$user_is_at_record_status_dashboard = $_SERVER['SCRIPT_NAME'] == APP_PATH_WEBROOT . "DataEntry/record_status_dashboard.php";
 		$pipe_all_records_button_configured = $this->getProjectSetting('piping-all-records-button');
@@ -76,9 +80,9 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 				$this->active_forms = [];  // framework quirk: [[0] => null]
 			}
 			$this->pipe_on_status = $this->getProjectSetting('pipe-on-status');
-			$this->formStatuses = $this->getFormStatusAllRecords($this->active_forms);
 
-			$this->pipeToRecord($record);
+			// Guarded piping — uses direct SQL guards instead of array-based formStatuses
+			$this->pipeToRecordSaveHook($record);
 		} finally {
 			self::$isPipingInProgress = false;
 		}
@@ -1004,7 +1008,109 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 		
 		return $data;
 	}
-	
+
+	/**
+	 * Checks whether a form/instance is locked.
+	 * Extracted from inline SQL in processRecord() (lines 382-386).
+	 */
+	function isFormLocked($project_id, $record, $event_id, $form_name, $instance) {
+		$project_id = intval($project_id);
+		$record = db_real_escape_string($record);
+		$event_id = intval($event_id);
+		$form_name = db_real_escape_string($form_name);
+		$instance = intval($instance);
+
+		$sql = "SELECT 1 FROM redcap_locking_data
+				WHERE project_id = $project_id
+				AND record = '$record'
+				AND event_id = $event_id
+				AND form_name = '$form_name'";
+
+		// Non-repeating forms may store instance as NULL or 1
+		if ($instance <= 1) {
+			$sql .= " AND (instance IS NULL OR instance = 1)";
+		} else {
+			$sql .= " AND instance = $instance";
+		}
+
+		$result = db_query($sql);
+		return db_num_rows($result) > 0;
+	}
+
+	/**
+	 * Checks whether a form's status exceeds the pipe-on-status threshold.
+	 * Extracted from inline SQL in processRecord() (lines 390-401).
+	 */
+	function isFormAbovePipeStatus($project_id, $record, $event_id, $form_name, $instance, $pipe_on_status) {
+		if ($pipe_on_status === null || $pipe_on_status === '') return false;
+
+		$project_id = intval($project_id);
+		$record = db_real_escape_string($record);
+		$event_id = intval($event_id);
+		$field_name = db_real_escape_string($form_name) . '_complete';
+		$instance = intval($instance);
+		$table = $this->getDataTable($project_id);
+
+		$sql = "SELECT value FROM $table
+				WHERE project_id = $project_id
+				AND record = '$record'
+				AND event_id = $event_id
+				AND field_name = '$field_name'";
+
+		// Data table stores non-repeating as instance IS NULL (never 1)
+		if ($instance <= 1) {
+			$sql .= " AND instance IS NULL";
+		} else {
+			$sql .= " AND instance = $instance";
+		}
+
+		$result = db_query($sql);
+		$row = db_fetch_assoc($result);
+		return !empty($row) && intval($row['value']) > intval($pipe_on_status);
+	}
+
+	/**
+	 * Checks whether a form is on the configured active-forms list.
+	 * Extracted from inline check in processRecord() (lines 374-378).
+	 */
+	function isFormOnActiveList($form_name, $active_forms) {
+		// Empty list or framework [null] quirk means all forms are active
+		if (empty($active_forms)) return true;
+		if (count($active_forms) == 1 && empty($active_forms[0])) return true;
+		return in_array($form_name, $active_forms);
+	}
+
+	/**
+	 * Batch-fetches all locking data for a project in a single SQL query.
+	 * Returns [$record][$event_id][$form_name][$instance] = true for O(1) lookups.
+	 * Currently unused — intended for future batch path optimization.
+	 */
+	function prefetchLockingData($project_id) {
+		$project_id = intval($project_id);
+		$sql = "SELECT record, event_id, form_name, instance
+				FROM redcap_locking_data
+				WHERE project_id = $project_id";
+		$result = db_query($sql);
+		$cache = [];
+		while ($row = db_fetch_assoc($result)) {
+			$inst = $row['instance'] ?? 1;
+			$cache[$row['record']][$row['event_id']][$row['form_name']][$inst] = true;
+		}
+		return $cache;
+	}
+
+	/**
+	 * Returns a cached \Project instance, avoiding repeated instantiation.
+	 * processDataTransfer() creates new \Project() on every call.
+	 */
+	function getCachedProject($pid) {
+		$pid = intval($pid);
+		if (!isset($this->projectCache[$pid])) {
+			$this->projectCache[$pid] = new \Project($pid);
+		}
+		return $this->projectCache[$pid];
+	}
+
 	function getSourceProjectsData() {
 		if (gettype($this->projects['source']) == 'Array') {
 			throw new \Exception("The Cross Project Piping module expected \$module->projects['source'] to be an array before calling pipeToRecord()");
@@ -1122,6 +1228,102 @@ class CrossprojectpipingExternalModule extends AbstractExternalModule
 		}
 
         return $returnarray;
+	}
+
+	/**
+	 * Save-hook piping wrapper with full guard enforcement.
+	 * Duplicates pipeToRecord() + processDataTransfer() iteration with three guards
+	 * (locking, active-forms, pipe-on-status) checked before any write per field.
+	 * Delegates data assembly to updateDestinationData() (unchanged).
+	 */
+	function pipeToRecordSaveHook($dst_rid) {
+		$record_match_info = $this->projects['destination']['records_match_fields'][$dst_rid];
+		if (empty($record_match_info)) {
+			return;
+		}
+
+		$dest_project_id = $this->projects['destination']['project_id'];
+		$resultData = [];
+
+		// Mirrors pipeToRecord() source project loop
+		foreach ($this->projects['source'] as $p_index => $src_project) {
+			$dest_match_field = $src_project['dest_match_field'];
+			$src_match_field = $src_project['source_match_field'];
+			$source_match_field_is_in_pipe_fields = in_array($src_match_field, $src_project['source_fields'], true) !== false;
+
+			foreach ($src_project['source_data'] as $src_rid => $src_rec) {
+				foreach ($src_rec as $eid => $field_data) {
+					if ($eid == "repeat_instances") {
+						foreach ($field_data as $ieid => $formData) {
+							foreach ($formData as $formName => $instanceData) {
+								foreach ($instanceData as $iNum => $subData) {
+									if ($subData[$src_match_field] != $record_match_info[$dest_match_field]) continue;
+									$resultData = $this->processDataTransferGuarded($resultData, $dst_rid, $src_project, $ieid, $subData, $src_match_field, $dest_match_field, $source_match_field_is_in_pipe_fields, $dest_project_id, $iNum);
+								}
+							}
+						}
+					} else {
+						if ($field_data[$src_match_field] != $record_match_info[$dest_match_field]) continue;
+						$resultData = $this->processDataTransferGuarded($resultData, $dst_rid, $src_project, $eid, $field_data, $src_match_field, $dest_match_field, $source_match_field_is_in_pipe_fields, $dest_project_id);
+					}
+				}
+			}
+		}
+
+		if (!empty($resultData[$dst_rid])) {
+			\REDCap::saveData('array', $resultData);
+		}
+	}
+
+	/**
+	 * Guarded version of processDataTransfer() for the save-hook path.
+	 * Inlines the same event-matching and field iteration logic but enforces
+	 * isFormLocked, isFormOnActiveList, and isFormAbovePipeStatus per field.
+	 * Uses getCachedProject() instead of inline new \Project().
+	 */
+	private function processDataTransferGuarded($currentData, $dst_rid, $src_project, $eid, $field_data, $src_match_field, $dest_match_field, $source_match_field_is_in_pipe_fields, $dest_project_id, $repeat_instance = "") {
+		// Match source event name to destination event (mirrors processDataTransfer event matching)
+		$src_event_name = $src_project['events'][$eid];
+		$dst_event_id = array_search($src_event_name, $this->projects['destination']['events'], true);
+		if ($dst_event_id === false) {
+			return $currentData;
+		}
+
+		// Validate event_id (mirrors processDataTransfer valid_match_event_ids check)
+		if (in_array($eid, (array) $src_project['valid_match_event_ids']) === false) {
+			return $currentData;
+		}
+
+		$destProj = $this->getCachedProject($dest_project_id);
+
+		foreach ($field_data as $field_name => $field_value) {
+			if ($field_name == $src_match_field && !$source_match_field_is_in_pipe_fields) {
+				continue;
+			}
+
+			$pipe_field_index = array_search($field_name, $src_project['source_fields'], true);
+			$dst_name = $src_project['dest_fields'][$pipe_field_index];
+			if (empty($dst_name)) continue;
+
+			$form_name = $src_project['dest_forms_by_field_name'][$dst_name];
+
+			// Guard block — all three checks before any write.
+			// $dst_event_id and $repeat_instance come from piping iteration context,
+			// not from redcap_save_record() hook parameters.
+			if ($this->isFormLocked($dest_project_id, $dst_rid, $dst_event_id, $form_name, $repeat_instance)) {
+				continue;
+			}
+			if (!$this->isFormOnActiveList($form_name, $this->active_forms)) {
+				continue;
+			}
+			if ($this->isFormAbovePipeStatus($dest_project_id, $dst_rid, $dst_event_id, $form_name, $repeat_instance, $this->pipe_on_status)) {
+				continue;
+			}
+
+			$currentData = $this->updateDestinationData($currentData, $destProj, $dst_name, $field_value, $dst_rid, $dst_event_id, $repeat_instance);
+		}
+
+		return $currentData;
 	}
 
     function processDataTransfer($currentData,$dst_rid,$src_project,$eid,$field_data,$src_match_field,$dest_match_field,$source_match_field_is_in_pipe_fields,$repeat_instance = "") {

--- a/config.json
+++ b/config.json
@@ -120,6 +120,11 @@
 			"repeatable": false
 		},
 		{
+			"key": "pipe-on-save",
+			"name": "Automatically pipe data when a record is saved (server-side)",
+			"type": "checkbox"
+		},
+		{
 			"key": "pipe-on-status",
 			"name": "Allow piping on forms this status or less",
 			"type": "dropdown",


### PR DESCRIPTION
# Pre-flight Checklist
- [ ] Are all the features in this PR tested?
- [ ] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [ ] Did you also update related documentation and tooling, such as .readme or tests?

>⚠️  **Note:** Testing and validation could not be performed — I do not currently have access to a REDCap development/test environment. This PR is submitted as a draft for review and validation by maintainers.

# Overview

## Cross-Project Piping Module Enhancement

This pull request introduces an optional server-side enhancement to the Cross-Project Piping module. This enhancement is submitted as one consolidated pull request organized into three logically distinct commits for review clarity:

1. **Commit A** — Optional Pipe-on-Save (minimal feature addition)
2. **Commit B** — Server-Side Guardrail Parity (save-hook only; existing paths untouched)
3. **Commit C** — Save-Hook Performance Improvements (scoped fetches; batch path unchanged)

Each commit is independently reviewable but together provides a cohesive enhancement.

All new methods include detailed docblocks documenting their relationship to existing code, the duplication rationale, and the future refactor path for collapsing duplication.

No JS, endpoints, or value resolution logic were modified beyond what is explicitly described.

> ⚠️ **Note:** This is a draft implementation. I do not currently have access to a REDCap development/test environment and am submitting this for review and validation by maintainers.

---

### Commit A — Optional Server-Side Pipe-on-Save

**Purpose**

Introduce an opt-in server-side pipe-on-save feature so cross-project piping can occur automatically when a destination record is saved via data entry.

This removes the need to:
- Open the form UI to trigger piping
- Use the Pipe All button

The feature is disabled by default.

**Changes**

**CrossprojectpipingExternalModule.php**
- Add:
  ```php
  private static $isPipingInProgress = false;
  ```
- Add `redcap_save_record()`:
  - Early return if:
    - `$record` is empty
    - recursion guard is active
    - `$survey_hash` is present (surveys excluded)
    - `pipe-on-save` setting is disabled
  - Initialize save-hook runtime context:
    - `$this->projects = $this->getProjects()`
    - `$this->projects['destination']['projectId'] = $this->projects['destination']['project_id']`
    - `$this->active_forms = $this->getProjectSetting('active-forms')`
    - `$this->pipe_on_status = $this->getProjectSetting('pipe-on-status')`
  - Reuse existing pipeline (same as batch endpoint):
    - `getSourceProjectsData()` — broad fetch of all source records
    - `getDestinationProjectData()` — broad fetch of all destination match fields
    - `pipeToRecord($record)` — existing piping method
  - Wrap piping call in `try/finally` to guarantee guard reset.
  - Note: Commits B and C progressively replace the pipeline calls within this method (see below).

**config.json**
- Add new checkbox setting:
  - `pipe-on-save`

**Behavioral Impact**
- No behavior changes unless explicitly enabled.
- UI form-load path unchanged.
- Pipe All behavior unchanged.

---

### Commit B — Server-Side Guardrail Parity (Save-Hook Path Only)

**Purpose**

Ensure the new server-side save-hook path enforces guardrails consistent with the UI form-load path.
Existing methods (`processRecord()`, `pipeToRecord()`, `processDataTransfer()`) are intentionally not modified.

**Changes**

**CrossprojectpipingExternalModule.php**

Add properties:
```php
private $lockingCache = null;
private $projectCache = [];
```

Add guard/helper methods:
- `isFormLocked(...)` — per-form/instance locking check via `redcap_locking_data`
- `isFormOnActiveList(...)` — active-forms list check (handles empty list and framework `[null]` quirk)
- `isFormAbovePipeStatus(...)` — form completion status threshold check via data table
- `prefetchLockingData(...)` — batch locking cache (implemented but not wired; reserved for future batch optimization)
- `getCachedProject(...)` — `\Project` instance cache to avoid repeated instantiation

Add save-hook-only guarded piping path (parallel to existing methods):
- `pipeToRecordSaveHook($record)` — replaces `pipeToRecord()` in `redcap_save_record()`
- `processDataTransferGuarded(...)` — mirrors `processDataTransfer()` with guard block enforced per field before any write

Update `redcap_save_record()`:
- Replace `pipeToRecord($record)` with `pipeToRecordSaveHook($record)`
- Remove `$this->formStatuses` fetch (no longer needed — `processDataTransferGuarded()` uses direct SQL via `isFormAbovePipeStatus()` instead of the array-based check in `processDataTransfer()`)

Guard enforcement in save-hook path:
- Skip write if form/instance is locked
- Skip write if form not on active-forms list
- Skip write if form status exceeds `pipe-on-status` threshold
- All three guards checked in a single decision block before any write per field

**Behavioral Impact**
- `processRecord()` remains unchanged.
- `pipeToRecord()` and `processDataTransfer()` remain unchanged.
- Batch endpoint remains unchanged.
- Save-hook path now respects locking, active-forms, and pipe-on-status consistently.
- After this commit, Commits A+B are a complete, production-safe deployment. Commit C is optional.

---

### Commit C — Save-Hook Performance Improvements (Scoped Fetch)

**Purpose**

Make the save-hook path scalable for large projects by avoiding full-project fetches on each save.
If reverted, save-hook falls back to Commit B's broad-fetch guarded pipeline — fully functional, fully guarded, just slower on large datasets.
Batch path performance is intentionally unchanged.

**Changes**

**CrossprojectpipingExternalModule.php**

Add:
- `getDestinationProjectDataForRecord($record_id)` — fetches only the target record's match field values via `'records' => [$record_id]`
- `getSourceProjectsDataForRecord($dest_match_info)` — constructs exact-match filterLogic (`[$match_field] = 'value'`) to pull only matching source records, with early return on empty match values

Update `redcap_save_record()`:
- Replace `getDestinationProjectData()` with `getDestinationProjectDataForRecord($record)`
- Replace `getSourceProjectsData()` with `getSourceProjectsDataForRecord($dest_match_info)`
- Add early return if all destination match field values are empty (checks actual values, not just array existence)

Known limitation (filterLogic escaping): single-quote escaping uses `str_replace` — match values containing backslashes or REDCap filterLogic metacharacters may produce incorrect filter expressions.

**Behavioral Impact**
- Save-hook behavior remains functionally consistent but no longer loads full-project datasets.
- Guard enforcement unchanged from Commit B.
- Pipe All path unchanged (no indexing or locking prefetch wired).
- No changes to matching semantics, repeat handling, or value resolution logic.

---

### Overall Impact of the PR

This pull request:
- Adds an optional production-ready pipe-on-save feature.
- Enforces server-side guardrails for the save-hook path only.
- Improves save-hook scalability via scoped fetches.
- Leaves UI and batch paths completely untouched.
- Introduces no JS or endpoint changes.
- Preserves existing configuration structure.

### Known Practical Notes
- `projectId` aliasing is required for compatibility with existing `processDataTransfer()` expectations.
- Dynamic properties (`active_forms`, `pipe_on_status`, `projects`, `formStatuses`) may trigger PHP 8.2 deprecation notices unless declared explicitly. These properties follow the existing codebase pattern (e.g., `$this->modSettings`, `$this->pipingMode`).
- FilterLogic escaping uses `str_replace("'", "\\'", ...)` — a simplification that may not handle all edge cases (see Commit C).

# Context

No associated Jira or tracker ticket. This enhancement was developed independently to address a practical gap: cross-project piping currently requires either opening the form UI or running Pipe All manually. The pipe-on-save feature allows piping to occur automatically on record save, which is particularly useful for workflows involving API-based data entry or high-volume data collection where manual form-load triggers are impractical.

# Screenshots

No UI changes. This PR adds server-side behavior only — a single `pipe-on-save` checkbox in the existing module configuration page. No new pages, components, or visual changes.
